### PR TITLE
Bump versions to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,13 +63,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.35</version>
+            <version>1.7.36</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.35</version>
+            <version>1.7.36</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -86,7 +86,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.9.0</version>
+                <version>3.10.0</version>
             </plugin>
             <!-- JUnit 5 requires Surefire version 2.22.1 or higher -->
             <plugin>
@@ -146,7 +146,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.3.1</version>
+                        <version>3.3.2</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -185,7 +185,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
+                        <version>1.6.12</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
* Bump slf4j-api from 1.7.35 to 1.7.36
* Bump slf4j-simple from 1.7.35 to 1.7.36
* Bump maven-javadoc-plugin from 3.3.1 to 3.3.2
* Bump nexus-staging-maven-plugin from 1.6.8 to 1.6.12
* Bump maven-compiler-plugin from 3.9.0 to 3.10.0